### PR TITLE
Partially addresses issue 6 in the zzapi-vscode repository

### DIFF
--- a/src/mergeData.ts
+++ b/src/mergeData.ts
@@ -51,7 +51,7 @@ function getMergedParams(commonParams: RawParams, requestParams: RawParams): Par
 
 function getMergedHeaders(
   commonHeaders: RawHeaders,
-  requestHeaders: RawHeaders,
+  requestHeaders: RawHeaders
 ): { [name: string]: string } {
   if (Array.isArray(commonHeaders)) {
     commonHeaders = getArrayHeadersAsObject(commonHeaders);
@@ -79,7 +79,7 @@ function getMergedOptions(cOptions: RawOptions = {}, rOptions: RawOptions = {}):
 
 function getMergedSetVars(
   setvars: RawSetVars = {},
-  captures: Captures = {},
+  captures: Captures = {}
 ): { mergedVars: SetVar[]; hasJsonVars: boolean } {
   const mergedVars: SetVar[] = [];
   let hasJsonVars = false;
@@ -152,7 +152,7 @@ function mergePrefixBasedTests(tests: RawTests) {
 
 function getMergedTests(
   cTests: RawTests = {},
-  rTests: RawTests = {},
+  rTests: RawTests = {}
 ): { mergedTests: Tests; hasJsonTests: boolean } {
   // Convert $. and h. at root level into headers and json keys
   mergePrefixBasedTests(cTests);
@@ -209,11 +209,11 @@ export function getMergedData(commonData: Common, requestData: RawRequest): Requ
 
   const { mergedTests: tests, hasJsonTests: hasJsonTests } = getMergedTests(
     commonData?.tests,
-    requestData.tests,
+    requestData.tests
   );
   const { mergedVars: setvars, hasJsonVars: hasJsonVars } = getMergedSetVars(
     requestData.setvars,
-    requestData.capture,
+    requestData.capture
   );
 
   const mergedData: RequestSpec = {

--- a/src/mergeData.ts
+++ b/src/mergeData.ts
@@ -51,7 +51,7 @@ function getMergedParams(commonParams: RawParams, requestParams: RawParams): Par
 
 function getMergedHeaders(
   commonHeaders: RawHeaders,
-  requestHeaders: RawHeaders
+  requestHeaders: RawHeaders,
 ): { [name: string]: string } {
   if (Array.isArray(commonHeaders)) {
     commonHeaders = getArrayHeadersAsObject(commonHeaders);
@@ -80,7 +80,7 @@ function getMergedOptions(cOptions: RawOptions = {}, rOptions: RawOptions = {}):
 
 function getMergedSetVars(
   setvars: RawSetVars = {},
-  captures: Captures = {}
+  captures: Captures = {},
 ): { mergedVars: SetVar[]; hasJsonVars: boolean } {
   const mergedVars: SetVar[] = [];
   let hasJsonVars = false;
@@ -153,7 +153,7 @@ function mergePrefixBasedTests(tests: RawTests) {
 
 function getMergedTests(
   cTests: RawTests = {},
-  rTests: RawTests = {}
+  rTests: RawTests = {},
 ): { mergedTests: Tests; hasJsonTests: boolean } {
   // Convert $. and h. at root level into headers and json keys
   mergePrefixBasedTests(cTests);
@@ -210,11 +210,11 @@ export function getMergedData(commonData: Common, requestData: RawRequest): Requ
 
   const { mergedTests: tests, hasJsonTests: hasJsonTests } = getMergedTests(
     commonData?.tests,
-    requestData.tests
+    requestData.tests,
   );
   const { mergedVars: setvars, hasJsonVars: hasJsonVars } = getMergedSetVars(
     requestData.setvars,
-    requestData.capture
+    requestData.capture,
   );
 
   const mergedData: RequestSpec = {

--- a/src/mergeData.ts
+++ b/src/mergeData.ts
@@ -73,8 +73,9 @@ function getMergedOptions(cOptions: RawOptions = {}, rOptions: RawOptions = {}):
   const keepRawJSON = options.keepRawJSON == true;
   const showHeaders = options.showHeaders == true;
   const rawParams = options.rawParams == true;
+  const stopOnFailure = options.stopOnFailure == true;
 
-  return { follow, verifySSL, keepRawJSON, showHeaders, rawParams };
+  return { follow, verifySSL, keepRawJSON, showHeaders, rawParams, stopOnFailure };
 }
 
 function getMergedSetVars(

--- a/src/models.ts
+++ b/src/models.ts
@@ -16,6 +16,7 @@ export interface Options {
   keepRawJSON: boolean;
   showHeaders: boolean;
   rawParams: boolean;
+  stopOnFailure: boolean;
 }
 
 export type Assertion = number | boolean | string | null | { [op: string]: any };
@@ -50,6 +51,7 @@ export interface RawOptions {
   keepRawJSON?: boolean;
   showHeaders?: boolean;
   rawParams?: boolean;
+  stopOnFailure?: boolean;
 }
 
 export interface RawTests {

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -8,11 +8,11 @@ export function runAllTests(tests: Tests, responseData: ResponseData): TestResul
   const results: TestResult[] = [];
   if (!tests) return results;
 
-  for (const spec in tests.json) {
-    const expected = tests.json[spec];
-    const received = getValueForJSONTests(responseData.json, spec);
-    const jsonResults = runTest(spec, expected, received);
-    results.push(...jsonResults);
+  if (tests.status) {
+    const expected = tests.status;
+    const received = responseData.status;
+    const statusResults = runTest("status", expected, received);
+    results.push(...statusResults);
   }
 
   for (const spec in tests.headers) {
@@ -22,18 +22,18 @@ export function runAllTests(tests: Tests, responseData: ResponseData): TestResul
     results.push(...headerResults);
   }
 
+  for (const spec in tests.json) {
+    const expected = tests.json[spec];
+    const received = getValueForJSONTests(responseData.json, spec);
+    const jsonResults = runTest(spec, expected, received);
+    results.push(...jsonResults);
+  }
+
   if (tests.body) {
     const expected = tests.body;
     const received = responseData.body;
     const bodyResults = runTest("body", expected, received);
     results.push(...bodyResults);
-  }
-
-  if (tests.status) {
-    const expected = tests.status;
-    const received = responseData.status;
-    const statusResults = runTest("status", expected, received);
-    results.push(...statusResults);
   }
 
   return results;
@@ -67,7 +67,7 @@ function getValueForJSONTests(responseContent: object, key: string): any {
 function runObjectTests(
   opVals: { [key: string]: any },
   receivedObject: any,
-  spec: string,
+  spec: string
 ): TestResult[] {
   let results: TestResult[] = [];
 

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -4,7 +4,11 @@ import { getStringIfNotScalar } from "./utils/typeUtils";
 
 import { Tests, ResponseData, TestResult, Assertion } from "./models";
 
-export function runAllTests(tests: Tests, responseData: ResponseData): TestResult[] {
+export function runAllTests(
+  tests: Tests,
+  responseData: ResponseData,
+  stopOnFailure: boolean
+): TestResult[] {
   const results: TestResult[] = [];
   if (!tests) return results;
 

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -12,12 +12,15 @@ export function runAllTests(
   const results: TestResult[] = [];
   if (!tests) return results;
 
+  let statusFail = false;
   if (tests.status) {
     const expected = tests.status;
     const received = responseData.status;
     const statusResults = runTest("status", expected, received);
     results.push(...statusResults);
+    statusFail = statusResults.some((r) => !r.pass);
   }
+  if (stopOnFailure && statusFail) return results;
 
   for (const spec in tests.headers) {
     const expected = tests.headers[spec];

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -7,7 +7,7 @@ import { Tests, ResponseData, TestResult, Assertion } from "./models";
 export function runAllTests(
   tests: Tests,
   responseData: ResponseData,
-  stopOnFailure: boolean
+  stopOnFailure: boolean,
 ): TestResult[] {
   const results: TestResult[] = [];
   if (!tests) return results;
@@ -74,7 +74,7 @@ function getValueForJSONTests(responseContent: object, key: string): any {
 function runObjectTests(
   opVals: { [key: string]: any },
   receivedObject: any,
-  spec: string
+  spec: string,
 ): TestResult[] {
   let results: TestResult[] = [];
 


### PR DESCRIPTION
- adds a stopOnFailure option, which when invoked prevents the running of header and body tests if status tests fail
- changes the order of running of tests:
1. status tests
2. header tests
3. json (body) tests
4. body assertions (regex, etc)