### PR TITLE
addresses issue 6 in zzapi-vscode

### DIFF
--- a/docs/zzapi-bundle-description.md
+++ b/docs/zzapi-bundle-description.md
@@ -165,6 +165,7 @@ Note that an assertion value can be a non-scalar, especially when matching a non
 Operators supported in the RHS are:
 * `$eq`, `$ne`, `$lt`, `$gt`, `$lte`, `$gte`: against the value
 * `$regex`: against the value, with `$options` like ignore-case
+* `$sw`, `$ew`, `$co`: to check if the target starts with, ends with or contains a string
 * `$size`: for length of arrays and objects, or the length of the string if it is not an array
 * `$exists`: true|false, to check existance of a field
 * `$type`: string|number|object|array|null: to check the type of the field

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -67,7 +67,7 @@ function getValueForJSONTests(responseContent: object, key: string): any {
 function runObjectTests(
   opVals: { [key: string]: any },
   receivedObject: any,
-  spec: string
+  spec: string,
 ): TestResult[] {
   let results: TestResult[] = [];
 

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -67,7 +67,7 @@ function getValueForJSONTests(responseContent: object, key: string): any {
 function runObjectTests(
   opVals: { [key: string]: any },
   receivedObject: any,
-  spec: string,
+  spec: string
 ): TestResult[] {
   let results: TestResult[] = [];
 
@@ -107,13 +107,18 @@ function runObjectTests(
       const options = opVals["$options"];
       const regex = new RegExp(expected, options);
       try {
-        pass = regex.test(received as string);
+        pass = typeof received === "string" && regex.test(received);
       } catch (err: any) {
         message = err.message;
       }
+    } else if (op === "$sw") {
+      pass = typeof received === "string" && received.startsWith(expected);
+    } else if (op === "$ew") {
+      pass = typeof received === "string" && received.endsWith(expected);
+    } else if (op === "$co") {
+      pass = typeof received === "string" && received.includes(expected);
     } else if (op == "$options") {
-      // Do nothing. $regex will address it.
-      continue;
+      continue; // do nothing. $regex will address it.
     } else {
       results.push({
         pass: false,


### PR DESCRIPTION
Introduces starts with (`$sw`), ends with (`$ew`) and contains (`$co`) tests as an alternative to regex patterns (`$regex`). 