### PR TITLE
introducing alternative syntax for partial equality / matching (zzapi-vscode #11)

### DIFF
--- a/src/mergeData.ts
+++ b/src/mergeData.ts
@@ -138,7 +138,7 @@ function getMergedSetVars(
  * $. and $h. prefixes, as this is more convenient when specifying them.
  * We merge these into tests.json and tests.headers respectively.
  */
-function mergePrefixBasedTests(tests: RawTests) {
+export function mergePrefixBasedTests(tests: RawTests) {
   if (!tests.json) tests.json = {};
   if (!tests.headers) tests.headers = {};
   for (const key of Object.keys(tests)) {

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -3,7 +3,7 @@ import jp from "jsonpath";
 import { getStringIfNotScalar, isDict } from "./utils/typeUtils";
 
 import { Tests, ResponseData, TestResult, Assertion } from "./models";
-import { getMergedTests, mergePrefixBasedTests } from "./mergeData";
+import { mergePrefixBasedTests } from "./mergeData";
 
 export function runAllTests(
   tests: Tests,
@@ -81,6 +81,7 @@ function runObjectTests(
   for (const op in opVals) {
     let expected = getStringIfNotScalar(opVals[op]);
     let received = getStringIfNotScalar(receivedObject);
+
     let pass = false;
     let message = "";
     if (op === "$eq") {
@@ -138,12 +139,14 @@ function runObjectTests(
     } else if (op === "$options") {
       continue; // do nothing. $regex will address it.
     } else if (op === "$test") {
-      if (!isDict(expected)) {
+      const originalExpected = opVals[op],
+        originalReceived = receivedObject;
+      if (!isDict(originalExpected)) {
         pass = false;
         message = "recursive tests must be dicts";
       } else {
-        mergePrefixBasedTests(expected);
-        const res = runAllTests(expected, received, false);
+        mergePrefixBasedTests(originalExpected);
+        const res = runAllTests(originalExpected, originalReceived, false);
         results.push(...res);
         continue;
       }

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -138,7 +138,7 @@ function runObjectTests(
       pass = typeof received === "string" && received.includes(expected);
     } else if (op === "$options") {
       continue; // do nothing. $regex will address it.
-    } else if (op === "$test") {
+    } else if (op === "$tests") {
       const originalExpected = opVals[op],
         originalReceived = receivedObject;
       if (!isDict(originalExpected)) {

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -139,14 +139,22 @@ function runObjectTests(
     } else if (op === "$options") {
       continue; // do nothing. $regex will address it.
     } else if (op === "$tests") {
-      const originalExpected = opVals[op],
-        originalReceived = receivedObject;
-      if (!isDict(originalExpected)) {
+      const recursiveTests = opVals[op];
+
+      if (!isDict(recursiveTests)) {
         pass = false;
         message = "recursive tests must be dicts";
       } else {
-        mergePrefixBasedTests(originalExpected);
-        const res = runAllTests(originalExpected, originalReceived, false);
+        mergePrefixBasedTests(recursiveTests);
+        const receivedObj: ResponseData = {
+          executionTime: 0,
+          body: "",
+          rawHeaders: "",
+          headers: {},
+          json: receivedObject,
+        };
+
+        const res = runAllTests(recursiveTests, receivedObj, false);
         results.push(...res);
         continue;
       }

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -8,7 +8,7 @@ import { mergePrefixBasedTests } from "./mergeData";
 export function runAllTests(
   tests: Tests,
   responseData: ResponseData,
-  stopOnFailure: boolean
+  stopOnFailure: boolean,
 ): TestResult[] {
   const results: TestResult[] = [];
   if (!tests) return results;
@@ -74,7 +74,7 @@ function getValueForJSONTests(responseContent: object, key: string): any {
 function runObjectTests(
   opVals: { [key: string]: any },
   receivedObject: any,
-  spec: string
+  spec: string,
 ): TestResult[] {
   let results: TestResult[] = [];
 


### PR DESCRIPTION
- [X] Introduces the feature requested in [#11 in zzapi-vscode](https://github.com/agrostar/zzapi-vscode/issues/11). 

Allows for partial equality / matching by using the `$tests` op. For example, the following:
```yaml
tests:
  $.args.foo1: bar1
  $.args.foo2: bar2
```

can be replaced with the following:
```yaml
tests: 
 $.args:
   $tests:
     $.foo1: bar1
     $.foo2: bar2
```
as stated in [this comment](https://github.com/agrostar/zzapi-vscode/issues/11#issuecomment-2116665010). 

- [ ] update the corresponding schema
