### PR TITLE
replace $env.X instances in values of variables with process.env[X]

### DIFF
--- a/src/replaceVars.ts
+++ b/src/replaceVars.ts
@@ -137,9 +137,10 @@ export function replaceVariablesInRequest(request: RequestSpec, variables: Varia
 
   type keyOfHttp = Exclude<keyof typeof request.httpRequest, "method">;
   const httpPropertiesToReplace: string[] = ["baseUrl", "url", "params", "headers", "body"];
-  httpPropertiesToReplace.forEach((key) => {
-    const replacedData = replaceVariables(request.httpRequest[key as keyOfHttp], variables);
-    request.httpRequest[key as keyOfHttp] = replacedData.data;
+  httpPropertiesToReplace.forEach((prop) => {
+    const httpKey = prop as keyOfHttp;
+    const replacedData = replaceVariables(request.httpRequest[httpKey], variables);
+    request.httpRequest[httpKey] = replacedData.data;
     undefs.push(...replacedData.undefinedVars);
   });
 

--- a/src/variableParser.ts
+++ b/src/variableParser.ts
@@ -52,6 +52,7 @@ function replaceEnvironmentVariables(vars: Variables): {
     if (envVarName in process.env) return process.env[envVarName];
 
     undefinedVars.push(envVarName);
+    return val;
   };
 
   const replacedVars: Variables = {};
@@ -63,7 +64,7 @@ function replaceEnvironmentVariables(vars: Variables): {
 export function loadVariables(
   envName: string | undefined,
   bundleContent: string | undefined,
-  varFileContents: string[],
+  varFileContents: string[]
 ): { vars: Variables; undefinedVars: string[] } {
   if (!envName) return { vars: {}, undefinedVars: [] };
 

--- a/src/variableParser.ts
+++ b/src/variableParser.ts
@@ -51,7 +51,7 @@ function replaceEnvironmentVariables(vars: Variables): {
     const envVarName = val.slice(PREFIX.length);
     if (envVarName in process.env) return process.env[envVarName];
 
-    undefinedVars.push(envVarName);
+    undefinedVars.push(val);
     return val;
   };
 

--- a/src/variableParser.ts
+++ b/src/variableParser.ts
@@ -59,7 +59,7 @@ export function loadVariables(
   bundleContent: string | undefined,
   varFileContents: string[],
 ): Variables {
-  if (!envName) return { vars: {}, undefinedVars: [] };
+  if (!envName) return {};
 
   const allBundleVariables = getBundleVariables(bundleContent);
   const bundleVars: Variables = allBundleVariables[envName] ?? {};
@@ -71,7 +71,7 @@ export function loadVariables(
   });
 
   const basicVars = Object.assign({}, envVars, bundleVars);
-  const { replacedVars: vars, undefinedVars } = replaceEnvironmentVariables(basicVars);
+  const vars = replaceEnvironmentVariables(basicVars);
 
-  return { vars, undefinedVars };
+  return vars;
 }

--- a/src/variableParser.ts
+++ b/src/variableParser.ts
@@ -64,7 +64,7 @@ function replaceEnvironmentVariables(vars: Variables): {
 export function loadVariables(
   envName: string | undefined,
   bundleContent: string | undefined,
-  varFileContents: string[]
+  varFileContents: string[],
 ): { vars: Variables; undefinedVars: string[] } {
   if (!envName) return { vars: {}, undefinedVars: [] };
 

--- a/src/variableParser.ts
+++ b/src/variableParser.ts
@@ -62,16 +62,12 @@ export function loadVariables(
   if (!envName) return {};
 
   const allBundleVariables = getBundleVariables(bundleContent);
-  const bundleVars: Variables = allBundleVariables.hasOwnProperty(envName)
-    ? allBundleVariables[envName]
-    : {};
+  const bundleVars: Variables = allBundleVariables[envName] ?? {};
 
-  let envVars: Variables = {};
+  const envVars: Variables = {};
   varFileContents.forEach((fileContents) => {
     const parsedData = YAML.parse(fileContents);
-    if (parsedData && isDict(parsedData[envName])) {
-      Object.assign(envVars, parsedData[envName]);
-    }
+    if (parsedData && isDict(parsedData[envName])) Object.assign(envVars, parsedData[envName]);
   });
 
   const basicVars = Object.assign({}, envVars, bundleVars);

--- a/src/variableParser.ts
+++ b/src/variableParser.ts
@@ -38,34 +38,27 @@ export function getEnvironments(bundleContent: string | undefined, varFileConten
   return [...uniqueNames];
 }
 
-function replaceEnvironmentVariables(vars: Variables): {
-  replacedVars: Variables;
-  undefinedVars: string[];
-} {
+function replaceEnvironmentVariables(vars: Variables): Variables {
   const PREFIX = "$env.";
 
-  const undefinedVars: string[] = [];
   const getVal = (val: any): any => {
     if (typeof val !== "string" || !val.startsWith(PREFIX)) return val;
 
     const envVarName = val.slice(PREFIX.length);
-    if (envVarName in process.env) return process.env[envVarName];
-
-    undefinedVars.push(val);
-    return val;
+    return envVarName in process.env ? process.env[envVarName] : val;
   };
 
   const replacedVars: Variables = {};
   for (const key in vars) replacedVars[key] = getVal(vars[key]);
 
-  return { replacedVars, undefinedVars };
+  return replacedVars;
 }
 
 export function loadVariables(
   envName: string | undefined,
   bundleContent: string | undefined,
   varFileContents: string[],
-): { vars: Variables; undefinedVars: string[] } {
+): Variables {
   if (!envName) return { vars: {}, undefinedVars: [] };
 
   const allBundleVariables = getBundleVariables(bundleContent);

--- a/src/variableParser.ts
+++ b/src/variableParser.ts
@@ -50,12 +50,14 @@ function replaceEnvironmentVariables(vars: Variables): Variables {
 
   const replacedVars: Variables = {};
   for (const key in vars) replacedVars[key] = getVal(vars[key]);
+
+  return replacedVars;
 }
 
 export function loadVariables(
   envName: string | undefined,
   bundleContent: string | undefined,
-  varFileContents: string[],
+  varFileContents: string[]
 ): Variables {
   if (!envName) return {};
 

--- a/src/variableParser.ts
+++ b/src/variableParser.ts
@@ -57,7 +57,7 @@ function replaceEnvironmentVariables(vars: Variables): Variables {
 export function loadVariables(
   envName: string | undefined,
   bundleContent: string | undefined,
-  varFileContents: string[]
+  varFileContents: string[],
 ): Variables {
   if (!envName) return {};
 

--- a/src/variableParser.ts
+++ b/src/variableParser.ts
@@ -55,7 +55,7 @@ function replaceEnvironmentVariables(vars: Variables): Variables {
 export function loadVariables(
   envName: string | undefined,
   bundleContent: string | undefined,
-  varFileContents: string[]
+  varFileContents: string[],
 ): Variables {
   if (!envName) return {};
 


### PR DESCRIPTION
Only replacing instances within the values of the definition of other variables, as requested in [the corresponding issue in zzapi-vscode](https://github.com/agrostar/zzapi-vscode/issues/10).