### PR TITLE
push status test results into SpecResult instance

### DIFF
--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -20,6 +20,7 @@ export function runAllTests(
     const received = responseData.status;
     const statusResults = runTest("status", expected, received, skip);
 
+    res.subResults.push(statusResults);
     if (stopOnFailure && statusResults.results.some((r) => !r.pass)) return res;
   }
 


### PR DESCRIPTION
Status tests were being run, but not being pushed into the SpecResult instance as pointed out [here](https://github.com/agrostar/zzapi-vscode/issues/18). 