### PR TITLE
replaces single quotes in curl content with '%27', does not add the 'user-agent' header

### DIFF
--- a/src/constructCurl.ts
+++ b/src/constructCurl.ts
@@ -13,7 +13,7 @@ export function getCurlRequest(request: RequestSpec): string {
   if (request.httpRequest.headers !== undefined) {
     for (const header in request.httpRequest.headers) {
       if (header === "user-agent") continue;
-      curl += ` -H \"${header}: ${request.httpRequest.headers[header]}\"`;
+      curl += ` -H '${header}: ${request.httpRequest.headers[header]}'`;
     }
   }
 

--- a/src/constructCurl.ts
+++ b/src/constructCurl.ts
@@ -11,8 +11,10 @@ export function getCurlRequest(request: RequestSpec): string {
 
   // headers
   if (request.httpRequest.headers !== undefined) {
-    for (const header in request.httpRequest.headers)
-      curl += ` -H '${header}: ${request.httpRequest.headers[header]}'`;
+    for (const header in request.httpRequest.headers) {
+      if (header === "user-agent") continue;
+      curl += ` -H \"${header}: ${request.httpRequest.headers[header]}\"`;
+    }
   }
 
   // body

--- a/src/constructCurl.ts
+++ b/src/constructCurl.ts
@@ -3,6 +3,11 @@ import { getStringValueIfDefined } from "./utils/typeUtils";
 import { getParamsForUrl, getURL } from "./executeRequest";
 import { RequestSpec } from "./models";
 
+function replaceSingleQuotes<T>(value: T): T {
+  if (typeof value !== "string") return value;
+  return value.replace(/'/g, "%27") as T & string;
+}
+
 export function getCurlRequest(request: RequestSpec): string {
   let curl: string = "curl";
 
@@ -13,13 +18,13 @@ export function getCurlRequest(request: RequestSpec): string {
   if (request.httpRequest.headers !== undefined) {
     for (const header in request.httpRequest.headers) {
       if (header === "user-agent") continue;
-      curl += ` -H '${header}: ${request.httpRequest.headers[header]}'`;
+      curl += ` -H '${replaceSingleQuotes(`${header}: ${request.httpRequest.headers[header]}`)}'`;
     }
   }
 
   // body
   if (request.httpRequest.body !== undefined)
-    curl += ` -d '${getStringValueIfDefined(request.httpRequest.body)}'`;
+    curl += ` -d '${replaceSingleQuotes(getStringValueIfDefined(request.httpRequest.body))}'`;
 
   // options.follow
   if (request.options.follow) curl += " -L";
@@ -31,10 +36,12 @@ export function getCurlRequest(request: RequestSpec): string {
   if (request.options.showHeaders) curl += " -i";
 
   // url w/ params
-  curl += ` '${getURL(
-    request.httpRequest.baseUrl,
-    request.httpRequest.url,
-    getParamsForUrl(request.httpRequest.params, request.options.rawParams),
+  curl += ` '${replaceSingleQuotes(
+    getURL(
+      request.httpRequest.baseUrl,
+      request.httpRequest.url,
+      getParamsForUrl(request.httpRequest.params, request.options.rawParams),
+    ),
   )}'`;
 
   return curl;

--- a/src/constructCurl.ts
+++ b/src/constructCurl.ts
@@ -17,7 +17,6 @@ export function getCurlRequest(request: RequestSpec): string {
   // headers
   if (request.httpRequest.headers !== undefined) {
     for (const header in request.httpRequest.headers) {
-      if (header === "user-agent") continue;
       curl += ` -H '${replaceSingleQuotes(`${header}: ${request.httpRequest.headers[header]}`)}'`;
     }
   }


### PR DESCRIPTION
- replaces single quotes in the headers, body, and url with '%27', before surrounding the content in single quotes
- ignores the "user-agent" header, to allow cURL to add its own user-agent header. 