### PR TITLE
feat: added support for path parameters

### DIFF
--- a/schemas/zzapi-bundle.schema.json
+++ b/schemas/zzapi-bundle.schema.json
@@ -51,9 +51,16 @@
         }
       }
     },
+    "pathParamObject": {
+      "type": "object",
+      "description": "A set of path parameters described as key/value pairs",
+      "properties": {
+        "": { "$ref": "#/$defs/scalar" }
+      }
+    },
     "headerObject": {
       "type": "object",
-      "description": "A set ofheaders described as key/value pairs",
+      "description": "A set of headers described as key/value pairs",
       "properties": {
         "": { "$ref": "#/$defs/scalar" }
       }
@@ -246,18 +253,14 @@
             "pathParams": {
               "description": "path parameters",
               "anyOf": [
-                {
-                  "type": "array",
-                  "items": { "$ref": "#/$defs/paramArray" }
-                },
-                { "$ref": "#/$defs/paramObject" }
+                { "$ref": "#/$defs/pathParamObject" }
               ]
             },
             "params": {
               "description": "Query string parameters",
               "anyOf": [
                 {
-                  "type": "array",
+                  "type": "array",  
                   "items": { "$ref": "#/$defs/paramArray" }
                 },
                 { "$ref": "#/$defs/paramObject" }

--- a/schemas/zzapi-bundle.schema.json
+++ b/schemas/zzapi-bundle.schema.json
@@ -243,6 +243,16 @@
                 { "$ref": "#/$defs/headerObject" }
               ]
             },
+            "pathParams": {
+              "description": "path parameters",
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": { "$ref": "#/$defs/paramArray" }
+                },
+                { "$ref": "#/$defs/paramObject" }
+              ]
+            },
             "params": {
               "description": "Query string parameters",
               "anyOf": [

--- a/src/executeRequest.ts
+++ b/src/executeRequest.ts
@@ -5,11 +5,15 @@ import { getStringValueIfDefined } from "./utils/typeUtils";
 import { GotRequest, Param, RequestSpec } from "./models";
 
 export function constructGotRequest(allData: RequestSpec): GotRequest {
-  const completeUrl: string = getURL(
+  var completeUrl: string = getURL(
     allData.httpRequest.baseUrl,
     allData.httpRequest.url,
     getParamsForUrl(allData.httpRequest.params, allData.options.rawParams),
   );
+
+  if(allData.httpRequest.pathParams){
+    completeUrl = substitutePathParams(completeUrl,allData.httpRequest.pathParams);
+  }
 
   const options: OptionsOfTextResponseBody = {
     method: allData.httpRequest.method.toLowerCase() as Method,
@@ -82,4 +86,34 @@ export function getURL(baseUrl: string | undefined, url: string, paramsForUrl: s
   if (!baseUrl || !url.startsWith("/")) return url + paramsForUrl;
   // otherwise, incorporate base url
   return baseUrl + url + paramsForUrl;
+}
+
+function substitutePathParams(url: string,params: Param[]): string {
+
+  const {baseUrl,path,query} = splitURL(url)
+  return baseUrl + path.replace(/:(\w+)/g, (_, key) => {
+      const param = params.find(p => p.name === key);
+      if (param) {
+          return encodeURIComponent(param.value); 
+      }
+      throw new Error(`Missing value for parameter: ${key}`);
+  }) + query;
+}
+
+function splitURL(url: string): { baseUrl: string; path: string; query: string } {
+  try {
+      // defaults to http if protocol not given
+      if (!/^\w+:\/\//.test(url)) {
+        url = "http://" + url;   
+      }
+      const parsedUrl = new URL(url);
+
+      return {
+          baseUrl: `${parsedUrl.protocol}//${parsedUrl.host}`,
+          path: parsedUrl.pathname, 
+          query: parsedUrl.search 
+      };
+  } catch (error) {
+      throw new Error("Invalid URL");
+  }
 }

--- a/src/mergeData.ts
+++ b/src/mergeData.ts
@@ -206,6 +206,7 @@ export function getMergedData(commonData: Common, requestData: RawRequest): Requ
 
   const method = requestData.method;
   const params = getMergedParams(commonData.params, requestData.params);
+  const pathParams = getMergedParams(commonData.pathParams,requestData.pathParams)
   const headers = getMergedHeaders(commonData.headers, requestData.headers);
   const body = requestData.body;
   const options = getMergedOptions(commonData.options, requestData.options);
@@ -226,6 +227,7 @@ export function getMergedData(commonData: Common, requestData: RawRequest): Requ
       url: requestData.url,
       method,
       params,
+      pathParams,
       headers,
       body,
     },

--- a/src/models.ts
+++ b/src/models.ts
@@ -73,6 +73,7 @@ export interface Common {
   baseUrl?: string;
   headers: RawHeaders;
   params: RawParams;
+  pathParams: RawParams;
   options?: RawOptions;
   tests?: RawTests;
 }
@@ -84,6 +85,7 @@ export interface RawRequest {
   method: Method;
   headers: RawHeaders;
   params: RawParams;
+  pathParams : RawParams;
   body?: string;
   options?: RawOptions;
   tests?: RawTests;
@@ -98,6 +100,7 @@ export interface RequestSpec {
     baseUrl?: string;
     url: string;
     method: Method;
+    pathParams : Param[];
     params: Param[];
     headers: { [key: string]: string };
     body?: any;


### PR DESCRIPTION
example.zzb
```
requests:
  simple-get:
    method: GET
    url: https://jsonplaceholder.typicode.com/:user/posts/:id
    pathParams:
      user: 1
      id: 3

final url would look like this : https://jsonplaceholder.typicode.com/1/posts/3
```