### PR TITLE
feat: added support for multipart formdata

### DIFF
--- a/docs/zzapi-bundle-description.md
+++ b/docs/zzapi-bundle-description.md
@@ -71,7 +71,10 @@ requests:
 * `method`: required, one of GET, POST, PUT, PATCH etc
 * `headers`: a set of headers, this will be in in addition to the common set, or overridden if the name is the same
 * `params`: a set of parameter values, or overridden if the name is the same
-* `body`: the raw request body. (Use the value `file://<filename>` to read from a file), or an object, which will be converted to a JSON string after variable replacements. If the value of any field is a file (specified using `file://<filename>`), the request will be sent as multipart/form-data, treating each key as a form field.
+* `body`: the raw request body. (Use the value `file://<filename>` to read from a file), or an object, which will be converted to a JSON string after variable replacements.
+* `formValues`: An object representing form fields to send in the request body. If no content-type is given and:
+  1. if none of the fields contain a file (specified as `file://<filename>`), the request will be sent as `application/x-www-form-urlencoded`.
+  2. if at least one field contains a file, the request will be sent as `multipart/form-data`.
 * `response*`: a set of sample responses, useful for documentation (doesn't affect the request)
   * `headers`: the headers expected in the response
   * `body`: the raw response body, or a JSON object. Use `<filename` to read from a file.

--- a/docs/zzapi-bundle-description.md
+++ b/docs/zzapi-bundle-description.md
@@ -71,7 +71,7 @@ requests:
 * `method`: required, one of GET, POST, PUT, PATCH etc
 * `headers`: a set of headers, this will be in in addition to the common set, or overridden if the name is the same
 * `params`: a set of parameter values, or overridden if the name is the same
-* `body`: the raw request body. (Use the value `file://<filename>` to read from a file), or an object, which will be converted to a JSON string after variable replacements.
+* `body`: the raw request body. (Use the value `file://<filename>` to read from a file), or an object, which will be converted to a JSON string after variable replacements. If the value of any field is a file (specified using `file://<filename>`), the request will be sent as multipart/form-data, treating each key as a form field.
 * `response*`: a set of sample responses, useful for documentation (doesn't affect the request)
   * `headers`: the headers expected in the response
   * `body`: the raw response body, or a JSON object. Use `<filename` to read from a file.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "form-data-encoder": "^4.0.2",
+    "formdata-node": "^6.0.3",
     "got": "11.8.6",
     "jsonpath": "^1.1.1",
     "yaml": "^2.3.4"

--- a/schemas/zzapi-bundle.schema.json
+++ b/schemas/zzapi-bundle.schema.json
@@ -257,6 +257,16 @@
               "description": "The request body",
               "type": ["string", "object", "array"] 
             },
+            "formValues":{
+              "description": "Put form values here.",
+              "anyOf":[
+                {
+                  "type": "array",
+                  "items": { "$ref": "#/$defs/headerArray" }
+                },
+                { "$ref": "#/$defs/headerObject" }
+              ]
+            },
             "options": { "$ref": "#/$defs/options" },
             "tests": { "$ref": "#/$defs/tests" },
             "capture": {

--- a/src/checkTypes.ts
+++ b/src/checkTypes.ts
@@ -217,6 +217,18 @@ export function validateRawRequest(obj: any): string | undefined {
     }
   }
 
+  if(obj.hasOwnProperty("formValues") && obj.hasOwnProperty("body")){
+    return `both body and formValues can't be present in the same request.`
+  }
+
+  if(obj.hasOwnProperty("method") && obj["method"] == "GET" && obj.hasOwnProperty("formValues")){
+    return `formValues can't be used with method GET`
+  }
+
+  if(obj.hasOwnProperty("method") && obj["method"] == "GET" && obj.hasOwnProperty("body")){
+    return `body can't be used with method GET`
+  } 
+
   return undefined;
 }
 

--- a/src/checkTypes.ts
+++ b/src/checkTypes.ts
@@ -5,7 +5,7 @@ function checkKey(
   item: string,
   key: string,
   expectedTypes: string[],
-  optional: boolean,
+  optional: boolean
 ): string | undefined {
   if (!optional && !obj.hasOwnProperty(key)) {
     return `${key} key must be present in each ${item} item`;
@@ -217,17 +217,17 @@ export function validateRawRequest(obj: any): string | undefined {
     }
   }
 
-  if(obj.hasOwnProperty("formValues") && obj.hasOwnProperty("body")){
-    return `both body and formValues can't be present in the same request.`
+  if (obj.hasOwnProperty("formValues") && obj.hasOwnProperty("body")) {
+    return `both body and formValues can't be present in the same request.`;
   }
 
-  if(obj.hasOwnProperty("method") && obj["method"] == "GET" && obj.hasOwnProperty("formValues")){
-    return `formValues can't be used with method GET`
+  if (obj.hasOwnProperty("method") && obj["method"] == "GET" && obj.hasOwnProperty("formValues")) {
+    return `formValues can't be used with method GET`;
   }
 
-  if(obj.hasOwnProperty("method") && obj["method"] == "GET" && obj.hasOwnProperty("body")){
-    return `body can't be used with method GET`
-  } 
+  if (obj.hasOwnProperty("method") && obj["method"] == "GET" && obj.hasOwnProperty("body")) {
+    return `body can't be used with method GET`;
+  }
 
   return undefined;
 }

--- a/src/constructCurl.ts
+++ b/src/constructCurl.ts
@@ -1,7 +1,7 @@
 import { getStringValueIfDefined } from "./utils/typeUtils";
 
 import { RequestSpec } from "./models";
-import { getParamsForUrl, getURL } from "./executeRequest";
+import { getParamsForUrl, getURL, handleMultiPart } from "./executeRequest";
 
 function replaceSingleQuotes<T>(value: T): T {
   if (typeof value !== "string") return value;
@@ -10,20 +10,40 @@ function replaceSingleQuotes<T>(value: T): T {
 
 export function getCurlRequest(request: RequestSpec): string {
   let curl: string = "curl";
-
+  const body = request.httpRequest.body
+  handleMultiPart(body,request,true);   //if any file:// found , changes content-type to multipart
   // method
   curl += ` -X ${request.httpRequest.method.toUpperCase()}`;
 
   // headers
   if (request.httpRequest.headers !== undefined) {
     for (const header in request.httpRequest.headers) {
+      if(header == 'content-type' && request.httpRequest.headers['content-type'] == 'multipart'){
+        continue;
+      }
       curl += ` -H '${replaceSingleQuotes(`${header}: ${request.httpRequest.headers[header]}`)}'`;
     }
   }
 
   // body
-  if (request.httpRequest.body !== undefined)
-    curl += ` -d '${replaceSingleQuotes(getStringValueIfDefined(request.httpRequest.body))}'`;
+  if (request.httpRequest.body !== undefined){
+    if(request.httpRequest.headers['content-type'] == 'multipart'){
+      for (const key in body) {
+        if (Object.prototype.hasOwnProperty.call(body, key)) {
+          if(Array.isArray(body[key])){
+            for (const element of body[key]) {
+              curl += ` -F "${key}=${element}"`;
+            }
+          }else{
+            curl += ` -F "${key}=${body[key]}"`;
+          }
+        }
+      }
+    }
+    else{
+      curl += ` -d '${replaceSingleQuotes(getStringValueIfDefined(request.httpRequest.body))}'`;
+    }
+  }
 
   // options.follow
   if (request.options.follow) curl += " -L";

--- a/src/constructCurl.ts
+++ b/src/constructCurl.ts
@@ -12,7 +12,7 @@ function formatCurlFormField(key: string, value: string): string {
   if (isFilePath(value)) {
     return ` --form ${key}=@"${path.resolve(value.slice(7))}"`;
   }
-  return ` --form '${key}="${value}"'`;
+  return ` --form '${key}="${encodeURIComponent(value)}"'`;
 }
 
 function getFormDataUrlEncoded(request: RequestSpec): string {
@@ -21,17 +21,10 @@ function getFormDataUrlEncoded(request: RequestSpec): string {
   let result = "";
 
   formValues.forEach((formValue: any) => {
-    result += `${formValue.name}=${formValue.value}&`;
+    result += ` --data "${formValue.name}=${encodeURIComponent(formValue.value)}"`;
   });
 
-  if (result.endsWith("&")) {
-    result = result.slice(0, -1);
-  }
-
-  if (result) {
-    return ` --data "${result}"`;
-  }
-  return "";
+  return result;
 }
 
 function getFormDataCurlRequest(request: RequestSpec): string {

--- a/src/constructCurl.ts
+++ b/src/constructCurl.ts
@@ -15,8 +15,9 @@ function formatCurlFormField(key: string, value: string): string {
   return ` --form '${key}="${value}"'`;
 }
 
-function getFormDataUrlEncoded(request: RequestSpec) {
+function getFormDataUrlEncoded(request: RequestSpec): string {
   const formValues = request.httpRequest.formValues;
+  if (!formValues) return "";
   let result = "";
 
   formValues.forEach((formValue: any) => {
@@ -35,6 +36,7 @@ function getFormDataUrlEncoded(request: RequestSpec) {
 
 function getFormDataCurlRequest(request: RequestSpec): string {
   const formValues = request.httpRequest.formValues;
+  if (!formValues) return "";
   let result = "";
   for (const { name, value } of formValues) {
     result += formatCurlFormField(name, value);
@@ -70,7 +72,7 @@ export function getCurlRequest(request: RequestSpec): string {
         getParamsForUrl(request.httpRequest.params, request.options.rawParams)
       )
     )}'`;
-    return curl
+    return curl;
   }
 
   // method

--- a/src/constructCurl.ts
+++ b/src/constructCurl.ts
@@ -8,7 +8,7 @@ function replaceSingleQuotes<T>(value: T): T {
   return value.replace(/'/g, "%27") as T & string;
 }
 
-function appendKeyValue(key: string, value: string): string {
+function formatCurlFormField(key: string, value: string): string {
   if (isFilePath(value)) {
     return ` --form ${key}=@"${fileURLToPath(value)}"`;
   }
@@ -21,10 +21,10 @@ function getFormDataCurlRequest(request: RequestSpec): string {
   for (const key in body) {
     if (Array.isArray(body[key])) {
       body[key].forEach((element: string) => {
-        result += appendKeyValue(key, element);
+        result += formatCurlFormField(key, element);
       });
     } else {
-      result += appendKeyValue(key, body[key]);
+      result += formatCurlFormField(key, body[key]);
     }
   }
   return result;

--- a/src/constructCurl.ts
+++ b/src/constructCurl.ts
@@ -1,48 +1,66 @@
-import { getStringValueIfDefined } from "./utils/typeUtils";
-
+import { getStringValueIfDefined, hasFile, isFilePath } from "./utils/typeUtils";
+import { fileURLToPath } from "url";
 import { RequestSpec } from "./models";
-import { getParamsForUrl, getURL, handleMultiPart } from "./executeRequest";
+import { getParamsForUrl, getURL } from "./executeRequest";
 
 function replaceSingleQuotes<T>(value: T): T {
   if (typeof value !== "string") return value;
   return value.replace(/'/g, "%27") as T & string;
 }
 
+function appendKeyValue(key: string, value: string): string {
+  if (isFilePath(value)) {
+    return ` --form ${key}=@"${fileURLToPath(value)}"`;
+  }
+  return ` --form '${key}="${value}"'`;
+}
+
+function getFormDataCurlRequest(request: RequestSpec): string {
+  const body = request.httpRequest.body;
+  let result = "";
+  for (const key in body) {
+    if (Array.isArray(body[key])) {
+      body[key].forEach((element: string) => {
+        result += appendKeyValue(key, element);
+      });
+    } else {
+      result += appendKeyValue(key, body[key]);
+    }
+  }
+  return result;
+}
+
 export function getCurlRequest(request: RequestSpec): string {
   let curl: string = "curl";
-  const body = request.httpRequest.body
-  handleMultiPart(body,request,true);   //if any file:// found , changes content-type to multipart
+
+  if (
+    request.httpRequest.headers["content-type"] == "multipart/form-data" ||
+    hasFile(request.httpRequest.body)
+  ) {
+    curl += getFormDataCurlRequest(request);
+    curl += ` '${replaceSingleQuotes(
+      getURL(
+        request.httpRequest.baseUrl,
+        request.httpRequest.url,
+        getParamsForUrl(request.httpRequest.params, request.options.rawParams)
+      )
+    )}'`;
+    return curl;
+  }
+
   // method
   curl += ` -X ${request.httpRequest.method.toUpperCase()}`;
 
   // headers
   if (request.httpRequest.headers !== undefined) {
     for (const header in request.httpRequest.headers) {
-      if(header == 'content-type' && request.httpRequest.headers['content-type'] == 'multipart'){
-        continue;
-      }
       curl += ` -H '${replaceSingleQuotes(`${header}: ${request.httpRequest.headers[header]}`)}'`;
     }
   }
 
   // body
-  if (request.httpRequest.body !== undefined){
-    if(request.httpRequest.headers['content-type'] == 'multipart'){
-      for (const key in body) {
-        if (Object.prototype.hasOwnProperty.call(body, key)) {
-          if(Array.isArray(body[key])){
-            for (const element of body[key]) {
-              curl += ` -F "${key}=${element}"`;
-            }
-          }else{
-            curl += ` -F "${key}=${body[key]}"`;
-          }
-        }
-      }
-    }
-    else{
-      curl += ` -d '${replaceSingleQuotes(getStringValueIfDefined(request.httpRequest.body))}'`;
-    }
+  if (request.httpRequest.body !== undefined) {
+    curl += ` -d '${replaceSingleQuotes(getStringValueIfDefined(request.httpRequest.body))}'`;
   }
 
   // options.follow
@@ -59,8 +77,8 @@ export function getCurlRequest(request: RequestSpec): string {
     getURL(
       request.httpRequest.baseUrl,
       request.httpRequest.url,
-      getParamsForUrl(request.httpRequest.params, request.options.rawParams),
-    ),
+      getParamsForUrl(request.httpRequest.params, request.options.rawParams)
+    )
   )}'`;
 
   return curl;

--- a/src/constructCurl.ts
+++ b/src/constructCurl.ts
@@ -1,7 +1,7 @@
 import { getStringValueIfDefined, hasFile, isFilePath } from "./utils/typeUtils";
-import { fileURLToPath } from "url";
 import { RequestSpec } from "./models";
 import { getParamsForUrl, getURL } from "./executeRequest";
+import path from "path";
 
 function replaceSingleQuotes<T>(value: T): T {
   if (typeof value !== "string") return value;
@@ -10,7 +10,7 @@ function replaceSingleQuotes<T>(value: T): T {
 
 function formatCurlFormField(key: string, value: string): string {
   if (isFilePath(value)) {
-    return ` --form ${key}=@"${fileURLToPath(value)}"`;
+    return ` --form ${key}=@"${path.resolve(value.slice(7))}"`;
   }
   return ` --form '${key}="${value}"'`;
 }

--- a/src/executeRequest.ts
+++ b/src/executeRequest.ts
@@ -4,7 +4,7 @@ import { getStringValueIfDefined, hasFile, isFilePath } from "./utils/typeUtils"
 
 import { GotRequest, Param, RequestSpec } from "./models";
 import { fileFromPathSync } from "formdata-node/file-from-path";
-import { fileURLToPath } from "url";
+
 import { FormDataEncoder } from "form-data-encoder";
 import { FormData } from "formdata-node";
 import { Readable } from "stream";
@@ -34,7 +34,8 @@ function replaceFilePath(filePath: string) {
   finds all file:// instances with atleast 1 succeeding word character
   matches the file-name referred to by this instance
   */
-  filePath = fileURLToPath(filePath);
+
+  filePath = path.resolve(filePath.slice(7));
   const fileName = path.basename(filePath);
   return fileFromPathSync(filePath, fileName);
 }

--- a/src/executeRequest.ts
+++ b/src/executeRequest.ts
@@ -29,13 +29,8 @@ export function constructGotRequest(allData: RequestSpec): GotRequest {
   return got(completeUrl, options);
 }
 
-function replaceFilePath(filePath: string) {
-  /*
-  finds all file:// instances with atleast 1 succeeding word character
-  matches the file-name referred to by this instance
-  */
-
-  filePath = path.resolve(filePath.slice(7));
+function getFileFromPath(filePath: string) {
+  filePath = path.resolve(filePath.slice(7)); // removes file:// prefix
   const fileName = path.basename(filePath);
   return fileFromPathSync(filePath, fileName);
 }
@@ -46,14 +41,14 @@ function constructFormData(request: RequestSpec, body: any) {
     if (Array.isArray(body[key])) {
       for (const element of body[key]) {
         if (isFilePath(element)) {
-          multipart.append(key, replaceFilePath(element));
+          multipart.append(key, getFileFromPath(element));
         } else {
           multipart.append(key, element);
         }
       }
     } else {
       if (isFilePath(body[key])) {
-        multipart.append(key, replaceFilePath(body[key]));
+        multipart.append(key, getFileFromPath(body[key]));
       } else {
         multipart.append(key, body[key]);
       }

--- a/src/executeRequest.ts
+++ b/src/executeRequest.ts
@@ -35,31 +35,31 @@ function getFileFromPath(filePath: string) {
   return fileFromPathSync(filePath, fileName);
 }
 
-function constructFormUrlEncoded(request: RequestSpec){
-  const formValues = request.httpRequest.formValues
-  const result = new URLSearchParams()
-  if(formValues){
-    request.httpRequest.headers["content-type"] = "application/x-www-form-urlencoded"
+function constructFormUrlEncoded(request: RequestSpec) {
+  const formValues = request.httpRequest.formValues;
+  if (!formValues) return "";
+  const result = new URLSearchParams();
+  if (formValues) {
+    request.httpRequest.headers["content-type"] = "application/x-www-form-urlencoded";
   }
 
-  for (const {name,value} of formValues) {
-    result.append(name,value)
+  for (const { name, value } of formValues) {
+    result.append(name, value);
   }
 
-  return result.toString()
+  return result.toString();
 }
 
 function constructFormData(request: RequestSpec) {
-  const formValues = request.httpRequest.formValues
-
+  const formValues = request.httpRequest.formValues;
+  if (!formValues) return;
   const multipart = new FormData();
 
-
   for (const fv of formValues) {
-    if(isFilePath(fv.value)){
-      multipart.append(fv.name,getFileFromPath(fv.value))
-    }else{
-      multipart.append(fv.name,fv.value)
+    if (isFilePath(fv.value)) {
+      multipart.append(fv.name, getFileFromPath(fv.value));
+    } else {
+      multipart.append(fv.name, fv.value);
     }
   }
   const fde = new FormDataEncoder(multipart);
@@ -70,15 +70,14 @@ function constructFormData(request: RequestSpec) {
 
 export function getBody(request: RequestSpec) {
   const body = request.httpRequest.body;
-  const formValues = request.httpRequest.formValues
+  const formValues = request.httpRequest.formValues;
 
   if (request.httpRequest.headers["content-type"] == "multipart/form-data" || hasFile(formValues)) {
     return constructFormData(request);
-
   }
 
-  if(formValues){
-    return constructFormUrlEncoded(request)
+  if (formValues) {
+    return constructFormUrlEncoded(request);
   }
 
   return getStringValueIfDefined(body);

--- a/src/executeRequest.ts
+++ b/src/executeRequest.ts
@@ -1,6 +1,6 @@
 import got, { Method, OptionsOfTextResponseBody } from "got";
 
-import { getStringValueIfDefined, isString, isFilePath } from "./utils/typeUtils";
+import { getStringValueIfDefined, hasFile, isFilePath } from "./utils/typeUtils";
 
 import { GotRequest, Param, RequestSpec } from "./models";
 import { fileFromPathSync } from "formdata-node/file-from-path";
@@ -36,23 +36,7 @@ function replaceFilePath(filePath: string) {
   */
   filePath = fileURLToPath(filePath);
   const fileName = path.basename(filePath);
-  console.log(filePath, fileName);
   return fileFromPathSync(filePath, fileName);
-}
-
-function hasFile(body: any): boolean {
-  for (const key in body) {
-    if (isString(body[key]) && isFilePath(body[key])) {
-      return true;
-    } else if (Array.isArray(body[key])) {
-      body[key].forEach((element: any) => {
-        if (isString(element) && isFilePath(element)) {
-          return true;
-        }
-      });
-    }
-  }
-  return false;
 }
 
 function constructFormData(request: RequestSpec, body: any) {
@@ -82,16 +66,11 @@ function constructFormData(request: RequestSpec, body: any) {
 
 export function getBody(request: RequestSpec) {
   const body = request.httpRequest.body;
-  console.log("body:", body);
   if (request.httpRequest.headers["content-type"] == "multipart/form-data" || hasFile(body)) {
-    const a = constructFormData(request, body);
-    console.log(a);
-    return a;
+    return constructFormData(request, body);
   }
 
-  const b = getStringValueIfDefined(body);
-  console.log(b);
-  return b;
+  return getStringValueIfDefined(body);
 }
 
 export async function executeGotRequest(httpRequest: GotRequest): Promise<{

--- a/src/mergeData.ts
+++ b/src/mergeData.ts
@@ -208,6 +208,7 @@ export function getMergedData(commonData: Common, requestData: RawRequest): Requ
   const params = getMergedParams(commonData.params, requestData.params);
   const headers = getMergedHeaders(commonData.headers, requestData.headers);
   const body = requestData.body;
+  const formValues = getMergedParams([],requestData.formValues)
   const options = getMergedOptions(commonData.options, requestData.options);
 
   const { mergedTests: tests, hasJsonTests: hasJsonTests } = getMergedTests(
@@ -228,6 +229,7 @@ export function getMergedData(commonData: Common, requestData: RawRequest): Requ
       params,
       headers,
       body,
+      formValues: formValues.length > 0 ? formValues : undefined
     },
     options,
     tests,

--- a/src/mergeData.ts
+++ b/src/mergeData.ts
@@ -51,7 +51,7 @@ function getMergedParams(commonParams: RawParams, requestParams: RawParams): Par
 
 function getMergedHeaders(
   commonHeaders: RawHeaders,
-  requestHeaders: RawHeaders,
+  requestHeaders: RawHeaders
 ): { [name: string]: string } {
   if (Array.isArray(commonHeaders)) {
     commonHeaders = getArrayHeadersAsObject(commonHeaders);
@@ -80,7 +80,7 @@ function getMergedOptions(cOptions: RawOptions = {}, rOptions: RawOptions = {}):
 
 function getMergedSetVars(
   setvars: RawSetVars = {},
-  captures: Captures = {},
+  captures: Captures = {}
 ): { mergedVars: SetVar[]; hasJsonVars: boolean } {
   const mergedVars: SetVar[] = [];
   let hasJsonVars = false;
@@ -155,7 +155,7 @@ export function mergePrefixBasedTests(tests: RawTests) {
 
 function getMergedTests(
   cTests: RawTests = {},
-  rTests: RawTests = {},
+  rTests: RawTests = {}
 ): { mergedTests: Tests; hasJsonTests: boolean } {
   // Convert $. and h. at root level into headers and json keys
   mergePrefixBasedTests(cTests);
@@ -208,16 +208,16 @@ export function getMergedData(commonData: Common, requestData: RawRequest): Requ
   const params = getMergedParams(commonData.params, requestData.params);
   const headers = getMergedHeaders(commonData.headers, requestData.headers);
   const body = requestData.body;
-  const formValues = getMergedParams([],requestData.formValues)
+  const formValues = getMergedParams([], requestData.formValues);
   const options = getMergedOptions(commonData.options, requestData.options);
 
   const { mergedTests: tests, hasJsonTests: hasJsonTests } = getMergedTests(
     commonData?.tests,
-    requestData.tests,
+    requestData.tests
   );
   const { mergedVars: setvars, hasJsonVars: hasJsonVars } = getMergedSetVars(
     requestData.setvars,
-    requestData.capture,
+    requestData.capture
   );
 
   const mergedData: RequestSpec = {
@@ -229,7 +229,7 @@ export function getMergedData(commonData: Common, requestData: RawRequest): Requ
       params,
       headers,
       body,
-      formValues: formValues.length > 0 ? formValues : undefined
+      formValues: formValues.length > 0 ? formValues : undefined,
     },
     options,
     tests,

--- a/src/models.ts
+++ b/src/models.ts
@@ -85,7 +85,7 @@ export interface RawRequest {
   headers: RawHeaders;
   params: RawParams;
   body?: string;
-  formValues?: RawHeaders;
+  formValues?: RawParams;
   options?: RawOptions;
   tests?: RawTests;
   capture?: Captures;
@@ -102,7 +102,7 @@ export interface RequestSpec {
     params: Param[];
     headers: { [key: string]: string };
     body?: any;
-    formValues?: any
+    formValues?: Param[];
   };
   expectJson: boolean;
   options: Options;

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,4 +1,4 @@
-import { CancelableRequest, Response, Method, OptionsOfTextResponseBody } from "got";
+import { CancelableRequest, Response, Method } from "got";
 
 export interface Header {
   name: string;
@@ -85,6 +85,7 @@ export interface RawRequest {
   headers: RawHeaders;
   params: RawParams;
   body?: string;
+  formValues?: RawHeaders;
   options?: RawOptions;
   tests?: RawTests;
   capture?: Captures;
@@ -101,6 +102,7 @@ export interface RequestSpec {
     params: Param[];
     headers: { [key: string]: string };
     body?: any;
+    formValues?: any
   };
   expectJson: boolean;
   options: Options;

--- a/src/utils/typeUtils.ts
+++ b/src/utils/typeUtils.ts
@@ -44,3 +44,18 @@ export function isFilePath(value: any): boolean {
   const fileRegex = /file:\/\/([^\s]+)/g;
   return fileRegex.test(value);
 }
+
+export function hasFile(body: any): boolean {
+  for (const key in body) {
+    if (isString(body[key]) && isFilePath(body[key])) {
+      return true;
+    } else if (Array.isArray(body[key])) {
+      body[key].forEach((element: any) => {
+        if (isString(element) && isFilePath(element)) {
+          return true;
+        }
+      });
+    }
+  }
+  return false;
+}

--- a/src/utils/typeUtils.ts
+++ b/src/utils/typeUtils.ts
@@ -45,16 +45,13 @@ export function isFilePath(value: any): boolean {
   return fileRegex.test(value);
 }
 
-export function hasFile(body: any): boolean {
-  for (const key in body) {
-    if (isString(body[key]) && isFilePath(body[key])) {
+export function hasFile(formValues: any): boolean {
+  if (!formValues) {
+    return false;
+  }
+  for (const formValue of formValues) {
+    if (isFilePath(formValue.value)) {
       return true;
-    } else if (Array.isArray(body[key])) {
-      for (const element of body[key]) {
-        if (isString(element) && isFilePath(element)) {
-          return true;
-        }
-      }
     }
   }
   return false;

--- a/src/utils/typeUtils.ts
+++ b/src/utils/typeUtils.ts
@@ -21,7 +21,7 @@ export function getStringIfNotScalar(data: any): Exclude<any, object> {
 
 export function getStringValueIfDefined<
   T extends undefined | Exclude<any, undefined>,
-  R = T extends undefined ? undefined : string,
+  R = T extends undefined ? undefined : string
 >(value: T): R {
   if (typeof value === "undefined") return undefined as R;
   if (typeof value === "object") return JSON.stringify(value) as R; // handles dicts, arrays, null, date (all obj)
@@ -31,4 +31,16 @@ export function getStringValueIfDefined<
 export function getStrictStringValue(value: any): string {
   if (typeof value === "undefined") return "undefined";
   return getStringValueIfDefined(value);
+}
+
+export function isString(value: any): boolean {
+  return typeof value === "string" || value instanceof String;
+}
+
+export function isFilePath(value: any): boolean {
+  if (!isString(value)) {
+    return false;
+  }
+  const fileRegex = /file:\/\/([^\s]+)/g;
+  return fileRegex.test(value);
 }

--- a/src/utils/typeUtils.ts
+++ b/src/utils/typeUtils.ts
@@ -50,11 +50,11 @@ export function hasFile(body: any): boolean {
     if (isString(body[key]) && isFilePath(body[key])) {
       return true;
     } else if (Array.isArray(body[key])) {
-      body[key].forEach((element: any) => {
+      for (const element of body[key]) {
         if (isString(element) && isFilePath(element)) {
           return true;
         }
-      });
+      }
     }
   }
   return false;

--- a/tests/bundles/auto-tests.zzb
+++ b/tests/bundles/auto-tests.zzb
@@ -411,8 +411,8 @@ requests:
     url: /post
     formValues:
       name: 
-      - file:///Users/vanshkoul/Desktop/services/zz/zzapi/tests/bundles/test-text-files/file1.txt
-      - file:///Users/vanshkoul/Desktop/services/zz/zzapi/tests/bundles/test-text-files/file2.txt
+      - file://./tests/bundles/test-text-files/file1.txt
+      - file://./tests/bundles/test-text-files/file2.txt
 
     tests:
       $.headers['content-type']: {$regex: multipart/form-data, $options : i}

--- a/tests/bundles/auto-tests.zzb
+++ b/tests/bundles/auto-tests.zzb
@@ -356,3 +356,53 @@ requests:
     tests:
       $.data.name: Tom
       $.data.address: { $eq: { city: Bangalore, pincode: 560002 } }
+
+  formdata-with-one-file:
+    method: POST
+    url: /post
+    body:
+      file: file://./tests/bundles/test-text-files/file1.txt
+    tests:
+      $.headers['content-type']: {$regex: multipart/form-data, $options : i}
+      $.files : {$size:  1}
+      $.files['file1.txt']: {$exists : true}
+
+  formdata-with-multiple-files:
+    method: POST
+    url: /post
+    body:
+      first: file://./tests/bundles/test-text-files/file2.txt
+      second: file://./tests/bundles/test-text-files/file3.txt
+      name: John
+    tests:
+      $.headers['content-type']: {$regex: multipart/form-data, $options : i}
+      $.files : {$size:  2}
+      $.files['file2.txt']: {$exists : true}
+      $.files['file3.txt']: {$exists : true}
+      $.form.name: John
+
+  formdata-without-files:
+    method: POST
+    url: /post
+    headers:
+      content-type: multipart/form-data
+    body:
+      foo: bar
+      count: 3
+    tests:
+      $.headers['content-type']: {$regex: multipart/form-data, $options : i}
+      $.form : {$size:  2}
+      $.form.foo : bar
+      $.form.count: "3"
+
+  formdata-multiple-files-under-same-key:
+    method: POST
+    url: /post
+    body:
+      name: 
+      - file://./tests/bundles/test-text-files/file3.txt
+      - file://./tests/bundles/test-text-files/file1.txt
+
+    tests:
+      $.headers['content-type']: {$regex: multipart/form-data, $options : i}
+      $.files : { $size : 2}

--- a/tests/bundles/auto-tests.zzb
+++ b/tests/bundles/auto-tests.zzb
@@ -357,10 +357,21 @@ requests:
       $.data.name: Tom
       $.data.address: { $eq: { city: Bangalore, pincode: 560002 } }
 
+  url-encoded-form-data:
+    method: POST
+    url: /post
+    formValues: 
+      firstName: John
+      lastName: Doe
+    tests:
+      $.headers['content-type']: {$regex: application/x-www-form-urlencoded, $options : i}
+      $.form.firstName: John
+      $.form.lastName: Doe
+      
   formdata-with-one-file:
     method: POST
     url: /post
-    body:
+    formValues:
       file: file://./tests/bundles/test-text-files/file1.txt
     tests:
       $.headers['content-type']: {$regex: multipart/form-data, $options : i}
@@ -370,7 +381,7 @@ requests:
   formdata-with-multiple-files:
     method: POST
     url: /post
-    body:
+    formValues:
       first: file://./tests/bundles/test-text-files/file2.txt
       second: file://./tests/bundles/test-text-files/file3.txt
       name: John
@@ -386,7 +397,7 @@ requests:
     url: /post
     headers:
       content-type: multipart/form-data
-    body:
+    formValues:
       foo: bar
       count: 3
     tests:
@@ -398,10 +409,10 @@ requests:
   formdata-multiple-files-under-same-key:
     method: POST
     url: /post
-    body:
+    formValues:
       name: 
-      - file://./tests/bundles/test-text-files/file3.txt
-      - file://./tests/bundles/test-text-files/file1.txt
+      - file:///Users/vanshkoul/Desktop/services/zz/zzapi/tests/bundles/test-text-files/file1.txt
+      - file:///Users/vanshkoul/Desktop/services/zz/zzapi/tests/bundles/test-text-files/file2.txt
 
     tests:
       $.headers['content-type']: {$regex: multipart/form-data, $options : i}

--- a/tests/bundles/test-text-files/file1.txt
+++ b/tests/bundles/test-text-files/file1.txt
@@ -1,0 +1,2 @@
+This file is definitely important.
+Probably.

--- a/tests/bundles/test-text-files/file2.txt
+++ b/tests/bundles/test-text-files/file2.txt
@@ -1,0 +1,2 @@
+Not a bug.
+A surprise feature.

--- a/tests/bundles/test-text-files/file3.txt
+++ b/tests/bundles/test-text-files/file3.txt
@@ -1,0 +1,2 @@
+Test file.
+Do not delete... unless you’re brave.


### PR DESCRIPTION
This PR introduces support for `multipart/form-data` and `application/x-www-form-urlencoded` in API requests. This PR adds a new attribute named `formValues` which is a set of key value pair. If content-type is not specified and formValue field is present then request will be sent as `application/x-www-form-urlencoded`. If there is at least one file given in `formValues` using `file://<filename>` then the request will be sent as `multipart/form-data`.

example.zzb
```
requests:
  Upload Files Example:
    url: http://example.org/upload
    method: POST
    formValues:
      username: "john.doe"
      age: "25"
      file1: file:///User/Desktop/test-1.txt
```

equivalent curl request:
```
curl --form 'username="john.doe"' --form 'age="25"' --form file1=@"/User/Desktop/test-1.txt" 'http://example.org/upload'
```
